### PR TITLE
Fix for Orientation

### DIFF
--- a/unicorn_hat_sim.py
+++ b/unicorn_hat_sim.py
@@ -67,7 +67,7 @@ class UnicornHatSim(object):
         pass
 
     def rotation(self, r):
-        self._rotation = int(round(r/90.0)) % 3
+        self._rotation = int(round(r/90.0)) % 4
 
     def clear(self):
         self.screen.fill((0, 0, 0))


### PR DESCRIPTION
The change in the module calculation corrects this issue and you can now choose between 90°, 180°, 270° or 360°.
Before this commit you are only able to choose between 90°, 180° or 360° as orientation.