### PR TITLE
Fix crash on non-square HATs

### DIFF
--- a/unicorn_hat_sim/__init__.py
+++ b/unicorn_hat_sim/__init__.py
@@ -104,7 +104,7 @@ class UnicornHatSim(object):
         elif rot == 270:
             xx = y
             yy = self.width - 1 - x
-        return (xx * self.width) + yy
+        return (xx * self.height) + yy
 
 
 # SD hats works as expected

--- a/unicorn_hat_sim/__init__.py
+++ b/unicorn_hat_sim/__init__.py
@@ -32,8 +32,7 @@ class UnicornHatSim(object):
         self.clear()
 
     def set_pixel(self, x, y, r, g, b):
-        i = (x * self.width) + y
-        self.pixels[i] = [int(r), int(g), int(b)]
+        self.pixels[self.index(x, y)] = [int(r), int(g), int(b)]
 
     def draw(self):
         for event in pygame.event.get():  # User did something


### PR DESCRIPTION
# tl;dr: To make your project work with Unicorn pHAT before this is merged...
### Using Command Line
```
pip3 uninstall unicorn-hat-sim
pip3 install git+git://github.com/adamkaplan/unicorn-hat-sim@patch-1#egg=unicorn-hat-sim
```
### Using Requirements.txt
Add the line: `git+git://github.com/adamkaplan/unicorn-hat-sim@patch-1#egg=unicorn-hat-sim`

## Change Summary

The Unicorn pHAT is 8x4, which crashes because it's not a square. The rows index should be offset by the columns, not the rows. I.e. in an 8x4 grid, the pixel index for row=2,col=3 would be row*height + col, or `2 * 4 + 3 = 11`.

Currently the code does row*width + col, or `2 * 8 + 3 = 19` and that will eventually crash!

Additionally, I changed `set_pixel` to use the existing rotation-normalized pixel index.