### PR TITLE
fix rotation value -  modulo computation

### DIFF
--- a/unicorn_hat_sim/__init__.py
+++ b/unicorn_hat_sim/__init__.py
@@ -69,7 +69,7 @@ class UnicornHatSim(object):
         pass
 
     def rotation(self, r):
-        self._rotation = int(round(r/90.0)) % 3
+        self._rotation = int(round(r/90.0)) % 4
 
     def clear(self):
         self.screen.fill((0, 0, 0))


### PR DESCRIPTION
Fixes issue #8 
Function arg to `rotation(int) ` can be in range [0, 360]. 
Internally, _rotation is stored as int with range [0, 3]. 
Thus, modulo argument needs to be 4.  