### PR TITLE
Modified clear method to match the behavior of unicornhathd

### DIFF
--- a/unicorn_hat_sim/__init__.py
+++ b/unicorn_hat_sim/__init__.py
@@ -29,7 +29,7 @@ class UnicornHatSim(object):
         pygame.display.set_caption("Unicorn HAT simulator")
         self.screen = pygame.display.set_mode(
             [self.window_width, self.window_height])
-        self.clear()
+        self.clear_display()
 
     def set_pixel(self, x, y, r, g, b):
         i = (x * self.width) + y
@@ -46,7 +46,7 @@ class UnicornHatSim(object):
                 self.draw_led(x, y)
 
     def show(self):
-        self.clear()
+        self.clear_display()
         self.draw()
         pygame.display.flip()
 
@@ -71,8 +71,11 @@ class UnicornHatSim(object):
     def rotation(self, r):
         self._rotation = int(round(r/90.0)) % 3
 
-    def clear(self):
+    def clear_display(self):
         self.screen.fill((0, 0, 0))
+
+    def clear(self):
+        self.pixels = [(0, 0, 0)] * self.width * self.height
 
     def get_rotation(self):
         return self._rotation * 90


### PR DESCRIPTION
I modified the clear method to clear the pixel buffer like unicornhathd.
I renamed the original clear method to clear_display and modified the original references to point to it, so that they can keep running the fill method on display.
This should fix issue #11